### PR TITLE
Fixed the bug which greyed out the guess field

### DIFF
--- a/redactle/index.js
+++ b/redactle/index.js
@@ -30,6 +30,8 @@ var yesterday;
 var articleName;
 var loadingIcon;
 
+var gameIsActive = false;
+
 function uuidv4() {
     return ([1e7] + 1e3 + 4e3 + 8e3 + 1e11).replace(/[018]/g, c =>
         (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
@@ -206,6 +208,7 @@ async function fetchData(retry, artStr) {
                     return;
                 }   
 
+                gameIsActive = true;
 
                 $(".mw-parser-output span").not(".punctuation").each(function () {
                     var txt = this.innerHTML.normalize('NFD').replace(/[\u0300-\u036f]/g, "").toLowerCase();
@@ -267,6 +270,9 @@ LoadSave();
 
 
 function PerformGuess(guessedWord, populate) {
+    if (!gameIsActive){
+      return;
+    }
     clickThruIndex = 0;
     RemoveHighlights(false);
     var normGuess = guessedWord.normalize('NFD').replace(/[\u0300-\u036f]/g, "").toLowerCase();
@@ -395,6 +401,7 @@ function LogGuess(guess, populate) {
 
 
 function WinRound(populate) {
+    gameIsActive = false;
     document.getElementById("userGuess").disabled = true;
     if (!pageRevealed) {
         const clap = new Audio('Clap.wav');

--- a/redactle/index.js
+++ b/redactle/index.js
@@ -123,7 +123,7 @@ async function fetchData(retry, artStr) {
                     seeAlso = document.getElementById("References").parentNode;
                 }
                 var e = document.getElementsByClassName('mw-parser-output');
-                if (!seeAlso) {
+                if (seeAlso) {
                     alsoIndex = Array.prototype.indexOf.call(seeAlso.parentNode.children, seeAlso);
                     for (var i = alsoIndex; i < e[0].children.length; i++) {
                         e[0].removeChild(e[0].children[i]);

--- a/redactle/rejectionFunctions.js
+++ b/redactle/rejectionFunctions.js
@@ -39,10 +39,10 @@ const rejectTooShort = (minWordCount) =>
 
 // -------------- ADD STUFF HERE ----------------------
 const rejectionFunctions = [            // elements must be (string -> bool), true means reject
-  // reject 70% of article with at least 5 words 'film'
-  rejectBasedOnTooManyWords("film", 5, 0.3),
-  // reject 40% of articles with at least 10 words 'player'
-  rejectBasedOnTooManyWords("player", 10, 0.6),
+  // reject 60% of article with at least 5 words 'film'
+  rejectBasedOnTooManyWords("film", 5, 0.4),
+  // reject 70% of articles with at least 8 words 'player'
+  rejectBasedOnTooManyWords("player", 8, 0.3),
   // reject all articles shorter than 300 words
   rejectTooShort(300),
 ]; 


### PR DESCRIPTION
The bug was caused by the following behavior:
- the game is won, the guess field is correctly disabled
- stone presses "new game", which re-activates the field and starts the asynchronous process to fetch the new article
- at the same time broken writes something in the chat, which triggers performGuess
- because there are no more words to guess in the current article's name, performGuess triggers WinRound, which again deactivates the field